### PR TITLE
Remove qiskit-terra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 llist==0.7.1
 matplotlib==3.7.1
 numpy==1.23.5
-qiskit==0.43.1
-qiskit_ibmq_provider==0.20.2
-qiskit_terra==0.24.1
+qiskit==0.43
+qiskit_ibmq_provider==0.20
+qiskit-aer==0.12
 scipy==1.10.1
 setuptools==67.8.0
 coverage==7.3.2


### PR DESCRIPTION
Qiskit is moving away from the `qiskit` metapackage architecture.  It is also redundant to also depend on `qiskit-terra`.

In the context of https://github.com/Nozidoali/quantum-xyz/issues/7, consider that `qiskit-terra` wont be supported in the `qiskit>=1` series.

| `qiskit` Metapackage Version | `qiskit-terra` | `qiskit-aer`  | `qiskit-ibmq-provider` |  Release Date |
|:--------------------------:|:------------:|:--------:|:-----------:|:------------:|
| 0.43.1                     | 0.24.1       | 0.12.0     |  0.20.2  | 2023-06-02   |

This PR includes the subpackage instead.